### PR TITLE
feat: 添加 OSS 独立上传代理设置

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -190,6 +190,7 @@ pub fn run() {
             upload::api::upload_provide_api_error,
             upload::queue::upload_set_max_concurrent,
             upload::queue::upload_set_max_retry,
+            upload::queue::upload_set_proxy,
             upload::queue::upload_enqueue_files,
             upload::queue::upload_enqueue_folder,
             upload::queue::upload_pause_task,

--- a/src-tauri/src/upload/oss.rs
+++ b/src-tauri/src/upload/oss.rs
@@ -19,12 +19,79 @@ use ali_oss_rs::multipart_common::{
 };
 use ali_oss_rs::object::ObjectOperations;
 use ali_oss_rs::object_common::{Callback, CallbackBodyType, PutObjectOptionsBuilder};
+use ali_oss_rs::reqwest::{Client as HttpClient, Proxy};
 use log::{error, info, warn};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::watch;
 
 use super::control::{UploadSignal, upload_signal_registry};
 use super::error::{UploadError, UploadResult, io_error, message_error};
+
+const UPLOAD_PROXY_ENV: &str = "OOF_UPLOAD_PROXY";
+
+/// 前端上传代理设置的一次任务级快照。
+///
+/// `url` 即使在关闭时也会保留，用来区分“用户显式关闭”与“从未配置”；后者允许读取
+/// `OOF_UPLOAD_PROXY` 作为启动级 fallback。
+#[derive(Clone, Default)]
+pub(crate) struct UploadProxyConfig {
+    enabled: bool,
+    url: String,
+}
+
+impl UploadProxyConfig {
+    pub(crate) fn new(enabled: bool, url: String) -> Self {
+        Self {
+            enabled,
+            url: url.trim().to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum UploadProxySource {
+    Setting,
+    Environment,
+}
+
+impl UploadProxySource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Setting => "setting",
+            Self::Environment => "environment",
+        }
+    }
+}
+
+struct EffectiveUploadProxy {
+    url: String,
+    source: UploadProxySource,
+}
+
+fn resolve_upload_proxy(
+    config: &UploadProxyConfig,
+    environment_proxy: Option<&str>,
+) -> Option<EffectiveUploadProxy> {
+    if config.enabled {
+        return Some(EffectiveUploadProxy {
+            url: config.url.clone(),
+            source: UploadProxySource::Setting,
+        });
+    }
+
+    // 地址非空说明用户保存过 UI 配置并显式关闭，此时不能再被环境变量重新启用。
+    if !config.url.is_empty() {
+        return None;
+    }
+
+    environment_proxy
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(|url| EffectiveUploadProxy {
+            url: url.to_string(),
+            source: UploadProxySource::Environment,
+        })
+}
 
 /// 上传中的进度快照事件。
 #[derive(serde::Serialize, Clone)]
@@ -70,6 +137,7 @@ pub(crate) async fn upload_to_oss_internal(
     callback_var: String,
     oss_upload_id: Option<String>,
     token_expiration_ms: Option<u64>,
+    upload_proxy: UploadProxyConfig,
     hooks: UploadHooks,
 ) -> UploadResult<String> {
     info!(
@@ -98,6 +166,7 @@ pub(crate) async fn upload_to_oss_internal(
         callback_var,
         oss_upload_id,
         token_expiration_ms,
+        upload_proxy,
         rx,
         hooks,
     )
@@ -138,6 +207,7 @@ async fn upload_file_impl(
     callback_var: String,
     oss_upload_id: Option<String>,
     token_expiration_ms: Option<u64>,
+    upload_proxy: UploadProxyConfig,
     rx: watch::Receiver<UploadSignal>,
     hooks: UploadHooks,
 ) -> UploadResult<String> {
@@ -158,9 +228,33 @@ async fn upload_file_impl(
     let clean_endpoint = endpoint
         .trim_start_matches("https://")
         .trim_start_matches("http://");
-    let client = ClientBuilder::new(&access_key_id, &access_key_secret, clean_endpoint)
+    let mut oss_builder = ClientBuilder::new(&access_key_id, &access_key_secret, clean_endpoint)
         .sts_token(&security_token)
-        .scheme("https")
+        .scheme("https");
+
+    let environment_proxy = std::env::var(UPLOAD_PROXY_ENV).ok();
+    if let Some(effective_proxy) = resolve_upload_proxy(&upload_proxy, environment_proxy.as_deref())
+    {
+        if effective_proxy.url.is_empty() {
+            return Err(message_error("解析上传代理", "代理地址不能为空"));
+        }
+
+        let proxy = Proxy::all(effective_proxy.url.as_str())
+            .map_err(|e| message_error("解析上传代理", e))?;
+        let http_client = HttpClient::builder()
+            .proxy(proxy)
+            .build()
+            .map_err(|e| message_error("创建上传代理客户端", e))?;
+
+        oss_builder = oss_builder.client(http_client);
+        info!(
+            "[上传任务][{}] 已启用上传代理 source={}",
+            upload_id,
+            effective_proxy.source.label()
+        );
+    }
+
+    let client = oss_builder
         .build()
         .map_err(|e| message_error("创建 OSS 客户端", e))?;
 
@@ -509,5 +603,70 @@ fn emit_oss_init(app: &AppHandle, hooks: &UploadHooks, event: OssUploadInitEvent
     let _ = app.emit("upload-oss-init", &event);
     if let Some(callback) = &hooks.on_oss_init {
         callback(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ClientBuilder, HttpClient, Proxy, UploadProxyConfig, UploadProxySource,
+        resolve_upload_proxy,
+    };
+
+    #[test]
+    fn enabled_setting_takes_priority_over_environment() {
+        let config = UploadProxyConfig::new(true, " http://127.0.0.1:7897 ".to_string());
+        let proxy = resolve_upload_proxy(&config, Some("http://127.0.0.1:7898")).unwrap();
+
+        assert_eq!(proxy.url, "http://127.0.0.1:7897");
+        assert!(proxy.source == UploadProxySource::Setting);
+    }
+
+    #[test]
+    fn disabled_saved_setting_suppresses_environment_fallback() {
+        let config = UploadProxyConfig::new(false, "http://127.0.0.1:7897".to_string());
+
+        assert!(resolve_upload_proxy(&config, Some("http://127.0.0.1:7898")).is_none());
+    }
+
+    #[test]
+    fn enabled_blank_setting_does_not_fall_back_to_environment() {
+        let config = UploadProxyConfig::new(true, "   ".to_string());
+        let proxy = resolve_upload_proxy(&config, Some("http://127.0.0.1:7898")).unwrap();
+
+        assert!(proxy.url.is_empty());
+        assert!(proxy.source == UploadProxySource::Setting);
+    }
+
+    #[test]
+    fn empty_unconfigured_setting_uses_environment_fallback() {
+        let config = UploadProxyConfig::default();
+        let proxy = resolve_upload_proxy(&config, Some(" http://127.0.0.1:7897 ")).unwrap();
+
+        assert_eq!(proxy.url, "http://127.0.0.1:7897");
+        assert!(proxy.source == UploadProxySource::Environment);
+    }
+
+    #[test]
+    fn blank_environment_proxy_is_ignored() {
+        let config = UploadProxyConfig::default();
+
+        assert!(resolve_upload_proxy(&config, Some("   ")).is_none());
+    }
+
+    #[test]
+    fn ali_oss_builder_accepts_reexported_proxy_client() {
+        let proxy = Proxy::all("http://127.0.0.1:7897").unwrap();
+        let http_client = HttpClient::builder().proxy(proxy).build().unwrap();
+
+        let result = ClientBuilder::new(
+            "access_key_id",
+            "access_key_secret",
+            "oss-cn-hangzhou.aliyuncs.com",
+        )
+        .client(http_client)
+        .build();
+
+        assert!(result.is_ok());
     }
 }

--- a/src-tauri/src/upload/queue.rs
+++ b/src-tauri/src/upload/queue.rs
@@ -31,13 +31,16 @@ use super::control::{upload_cancel, upload_pause};
 use super::error::UploadError;
 use super::folder::{enqueue_folder_impl, sync_parent_folder};
 use super::local::compute_file_hash_internal;
-use super::oss::{OssUploadInitEvent, UploadHooks, UploadProgressEvent, upload_to_oss_internal};
+use super::oss::{
+    OssUploadInitEvent, UploadHooks, UploadProgressEvent, UploadProxyConfig, upload_to_oss_internal,
+};
 use super::progress::UploadProgressRegistry;
 use super::store::{DbHandle, TaskUpdate, UploadStoreError, UploadTask};
 use super::sync::UploadStateSync;
 
 const ERR_QUEUE_CHANNEL_CLOSED: &str = "上传队列不可用：调度通道已关闭";
 const ERR_COLLECTION_STATE_POISONED: &str = "上传收集状态异常：内部锁已损坏";
+const ERR_PROXY_STATE_POISONED: &str = "上传代理设置异常：内部锁已损坏";
 const STATUS_PAUSED: &str = "paused";
 const STATUS_PAUSING: &str = "pausing";
 
@@ -170,6 +173,7 @@ pub struct UploadQueue {
     control_tx: mpsc::Sender<ControlCommand>,
     max_concurrent: Arc<AtomicUsize>,
     max_retry: Arc<AtomicUsize>,
+    upload_proxy: Arc<Mutex<UploadProxyConfig>>,
     collecting_folders: Arc<Mutex<HashSet<String>>>,
     cancelled_folder_collections: Arc<Mutex<HashSet<String>>>,
     paused_folders: Arc<Mutex<HashSet<String>>>,
@@ -189,6 +193,7 @@ impl UploadQueue {
         let (completion_tx, completion_rx) = mpsc::channel::<TaskCompletion>(256);
         let max_concurrent = Arc::new(AtomicUsize::new(3));
         let max_retry = Arc::new(AtomicUsize::new(3));
+        let upload_proxy = Arc::new(Mutex::new(UploadProxyConfig::default()));
         let collecting_folders = Arc::new(Mutex::new(HashSet::new()));
         let cancelled_folder_collections = Arc::new(Mutex::new(HashSet::new()));
         let paused_folders = Arc::new(Mutex::new(HashSet::new()));
@@ -199,6 +204,7 @@ impl UploadQueue {
             control_tx,
             max_concurrent,
             max_retry,
+            upload_proxy,
             collecting_folders,
             cancelled_folder_collections,
             paused_folders,
@@ -317,6 +323,15 @@ impl UploadQueue {
         self.max_retry.store(n.min(10), Ordering::SeqCst);
     }
 
+    fn set_upload_proxy(&self, enabled: bool, url: String) -> Result<(), UploadQueueError> {
+        let mut config = self
+            .upload_proxy
+            .lock()
+            .map_err(|_| UploadQueueError::Internal(ERR_PROXY_STATE_POISONED.into()))?;
+        *config = UploadProxyConfig::new(enabled, url);
+        Ok(())
+    }
+
     fn collection_lock(
         set: &Mutex<HashSet<String>>,
     ) -> Result<std::sync::MutexGuard<'_, HashSet<String>>, UploadQueueError> {
@@ -416,6 +431,7 @@ async fn queue_loop(
                     state_sync.clone(),
                     api_resolver.clone(),
                     max_retry.clone(),
+                    queue.upload_proxy.clone(),
                 );
                 active.insert(id, handle);
             } else {
@@ -920,6 +936,7 @@ fn spawn_upload_task(
     state_sync: UploadStateSync,
     api_resolver: Arc<UploadApiResolver>,
     max_retry: Arc<AtomicUsize>,
+    upload_proxy: Arc<Mutex<UploadProxyConfig>>,
 ) -> JoinHandle<()> {
     tauri::async_runtime::spawn(async move {
         let completion = run_upload_task(
@@ -930,6 +947,7 @@ fn spawn_upload_task(
             state_sync,
             api_resolver,
             max_retry,
+            upload_proxy,
         )
         .await;
         let _ = completion_tx.send(completion).await;
@@ -950,8 +968,18 @@ async fn run_upload_task(
     state_sync: UploadStateSync,
     api_resolver: Arc<UploadApiResolver>,
     max_retry: Arc<AtomicUsize>,
+    upload_proxy: Arc<Mutex<UploadProxyConfig>>,
 ) -> TaskCompletion {
     let max_attempts = max_retry.load(Ordering::SeqCst);
+    let upload_proxy = match upload_proxy.lock() {
+        Ok(config) => config.clone(),
+        Err(_) => {
+            return TaskCompletion::Failed {
+                id: task.id,
+                error: ERR_PROXY_STATE_POISONED.to_string(),
+            };
+        }
+    };
 
     for attempt in 0..=max_attempts {
         info!(
@@ -960,8 +988,16 @@ async fn run_upload_task(
             attempt + 1,
             max_attempts + 1
         );
-        match run_upload_task_once(&task, &mut signal_rx, &app, &db, &state_sync, &api_resolver)
-            .await
+        match run_upload_task_once(
+            &task,
+            &mut signal_rx,
+            &app,
+            &db,
+            &state_sync,
+            &api_resolver,
+            &upload_proxy,
+        )
+        .await
         {
             Ok(TaskCompletion::Completed { .. }) => {
                 info!(
@@ -1079,6 +1115,7 @@ async fn run_upload_task_once(
     db: &DbHandle,
     state_sync: &UploadStateSync,
     api_resolver: &Arc<UploadApiResolver>,
+    upload_proxy: &UploadProxyConfig,
 ) -> Result<TaskCompletion, TaskCompletion> {
     if let Some(completion) = check_signal(signal_rx) {
         return Ok(completion_for(task, completion));
@@ -1211,6 +1248,7 @@ async fn run_upload_task_once(
             db,
             state_sync,
             api_resolver,
+            upload_proxy,
         )
         .await
         {
@@ -1248,6 +1286,7 @@ async fn execute_oss_upload(
     db: &DbHandle,
     state_sync: &UploadStateSync,
     api_resolver: &Arc<UploadApiResolver>,
+    upload_proxy: &UploadProxyConfig,
 ) -> Result<(), UploadError> {
     let _ = safe_update_task(
         db,
@@ -1387,6 +1426,7 @@ async fn execute_oss_upload(
             target.callback.callback_var.clone(),
             current_oss_upload_id.clone(),
             token_expiration_ms,
+            upload_proxy.clone(),
             hooks,
         )
         .await
@@ -1751,6 +1791,16 @@ pub async fn upload_set_max_retry(
 ) -> Result<(), UploadQueueError> {
     queue.set_max_retry(n);
     Ok(())
+}
+
+/// 更新新启动 OSS 任务使用的独立上传代理设置。
+#[tauri::command]
+pub async fn upload_set_proxy(
+    enabled: bool,
+    url: String,
+    queue: tauri::State<'_, UploadQueue>,
+) -> Result<(), UploadQueueError> {
+    queue.set_upload_proxy(enabled, url)
 }
 
 /// 批量创建普通文件上传任务并入队。

--- a/src/composables/useUploadManager.ts
+++ b/src/composables/useUploadManager.ts
@@ -305,8 +305,15 @@ export const useUploadManager = createSharedComposable(() => {
     await invokeUploadCommand('upload_set_max_retry', { n });
   };
 
+  const syncUploadProxy = async (
+    enabled = Boolean(settingStore.uploadSetting.uploadProxyEnabled),
+    url = settingStore.uploadSetting.uploadProxy || '',
+  ) => {
+    await invokeUploadCommand('upload_set_proxy', { enabled, url });
+  };
+
   const syncUploadSettings = async () => {
-    await Promise.all([syncMaxConcurrent(), syncMaxRetry()]);
+    await Promise.all([syncMaxConcurrent(), syncMaxRetry(), syncUploadProxy()]);
   };
 
   // 远端目录创建仍复用现有前端 API，并带上限流退避，避免文件夹批量展开时击穿接口。
@@ -501,6 +508,17 @@ export const useUploadManager = createSharedComposable(() => {
         (n) => {
           void syncMaxRetry(n).catch((error) => {
             logUploadManagerError('同步上传重试设置失败:', error);
+          });
+        },
+      ),
+      watch(
+        [
+          () => settingStore.uploadSetting.uploadProxyEnabled,
+          () => settingStore.uploadSetting.uploadProxy,
+        ],
+        ([enabled, url]) => {
+          void syncUploadProxy(Boolean(enabled), url || '').catch((error) => {
+            logUploadManagerError('同步上传代理设置失败:', error);
           });
         },
       ),

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -65,6 +65,10 @@ export const useSettingStore = defineStore(
       maxRetry: 3,
       /** 并行上传任务数 */
       maxConcurrent: 5,
+      /** 是否为 OSS 数据上传启用独立代理 */
+      uploadProxyEnabled: false,
+      /** OSS 数据上传代理地址 */
+      uploadProxy: '',
     });
 
     const subtitleStyleSetting = ref({

--- a/src/views/Setting/SettingView.vue
+++ b/src/views/Setting/SettingView.vue
@@ -278,6 +278,24 @@
               :step="1"
             />
           </NFormItem>
+          <NFormItem label="启用上传代理" path="uploadSetting.uploadProxyEnabled">
+            <NSwitch v-model:value="settingStore.uploadSetting.uploadProxyEnabled" />
+          </NFormItem>
+          <NFormItem label="代理类型">
+            <NSelect value="HTTP" :options="UPLOAD_PROXY_TYPE_OPTIONS" class="w-40" disabled />
+          </NFormItem>
+          <NFormItem
+            label="代理地址"
+            path="uploadSetting.uploadProxy"
+            :validation-status="uploadProxyValidationStatus"
+            :feedback="uploadProxyValidationFeedback"
+          >
+            <NInput
+              v-model:value="settingStore.uploadSetting.uploadProxy"
+              placeholder="http://127.0.0.1:7897"
+              clearable
+            />
+          </NFormItem>
         </NForm>
       </NTabPane>
     </NTabs>
@@ -301,6 +319,29 @@
     { label: 'Warn', value: 'warn' },
     { label: 'Error', value: 'error' },
   ];
+  const UPLOAD_PROXY_TYPE_OPTIONS = [{ label: 'HTTP', value: 'HTTP' }];
+
+  const uploadProxyValidationFeedback = computed(() => {
+    if (!settingStore.uploadSetting.uploadProxyEnabled) return undefined;
+
+    const proxyUrl = settingStore.uploadSetting.uploadProxy.trim();
+    if (!proxyUrl) return '启用上传代理后必须填写代理地址';
+
+    try {
+      const parsedUrl = new URL(proxyUrl);
+      if (!['http:', 'https:'].includes(parsedUrl.protocol) || !parsedUrl.hostname) {
+        return '请输入有效的 HTTP 或 HTTPS 代理地址';
+      }
+    } catch {
+      return '请输入有效的 HTTP 或 HTTPS 代理地址';
+    }
+
+    return undefined;
+  });
+
+  const uploadProxyValidationStatus = computed<'error' | undefined>(() =>
+    uploadProxyValidationFeedback.value ? 'error' : undefined,
+  );
 
   /** 字幕预览样式 */
   const subtitlePreviewStyle = computed<CSSProperties>(() => {


### PR DESCRIPTION
## 变更说明

- 新增独立的上传代理开关和地址设置，不复用更新代理 `updateProxy`
- 代理配置通过 Tauri command 同步到上传队列，并在新任务启动时获取不可变快照
- 使用 `ali_oss_rs::reqwest::{Client, Proxy}` 创建代理客户端，避免项目 Reqwest 0.13 与 ali-oss-rs Reqwest 0.12 的类型冲突
- 未配置 UI 上传代理时支持 `OOF_UPLOAD_PROXY` 环境变量 fallback

<img width="1625" height="622" alt="image" src="https://github.com/user-attachments/assets/9321597f-e6b6-4426-80c9-301f85b7c8fb" />

## 行为边界

- 代理仅用于 OSS 数据上传，不影响更新请求和 115 API 请求
- 设置只影响之后启动的上传任务，已在执行中的任务不会切换客户端
- UI 已保存代理并显式关闭时，不会被环境变量重新启用
- 当前支持 HTTP/HTTPS 代理地址

## 验证

- `pnpm run type-check`
- `pnpm run build-only`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --offline`：6 passed
- 实际上传代理流程已手动验证
- [GitHub Actions 四平台完整打包通过](https://github.com/YuSaZh/115-plus-desktop/actions/runs/31958070390)（验证提交仅额外包含 fork 临时 CI 配置，该配置未进入本 PR）
- 已在Windows/Ubuntu平台实测，可正常使用